### PR TITLE
reduce Npath complexity

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -426,11 +426,9 @@ final class RuleSetFactory {
             }
         }
 
-        if (!excludedRulesCheck.isEmpty()) {
-            excludedRulesCheck.forEach(
-                (name, elt) ->
-                    err.at(elt).warn("Exclude pattern ''{0}'' did not match any rule in ruleset ''{1}''", name, ref));
-        }
+        excludedRulesCheck.forEach(
+        (name, elt) ->
+            err.at(elt).warn("Exclude pattern ''{0}'' did not match any rule in ruleset ''{1}''", name, ref));
 
         if (rulesetReferences.contains(ref)) {
             err.at(ruleElement).warn("The ruleset {0} is referenced multiple times in ruleset ''{1}''", ref, ruleSetBuilder.getName());


### PR DESCRIPTION
## Reduce Npath complexity

## Related issues
The method 'parseRuleSetReferenceNode(RuleSetBuilder, Element, String, RuleSetReferenceId, Set, PmdXmlReporter)' has an NPath complexity of 2016. The current threshold is 200

- Fixes #
Removing the if statement that checks if "potentialRules" is empty, since the loop won't execute if the list is empty, there is no need to check again, thus reducing Npath complexity. 

